### PR TITLE
Update code to run without timefixed data errors 

### DIFF
--- a/R/pred_MMT.R
+++ b/R/pred_MMT.R
@@ -34,8 +34,8 @@ pred.MMT <- function(tree, Longitudinal=NULL, Numeric=NULL, Factor=NULL,
       var.split.sum <- as.numeric(as.character(tree$V_split[which(tree$V_split[,2]==current_node),4]))
       threshold <- as.numeric(as.character(tree$V_split[which(tree$V_split[,2]==current_node),5]))
 
-      meanG <- tree$hist_nodes[[as.character(2*current_node)]]
-      meanD <- tree$hist_nodes[[as.character(2*current_node+1)]]
+      meanG <- tree$hist_nodes[[as.numeric(2*current_node)]]
+      meanD <- tree$hist_nodes[[as.numeric(2*current_node+1)]]
 
       if (type=="longitudinal"){
 
@@ -48,7 +48,7 @@ pred.MMT <- function(tree, Longitudinal=NULL, Numeric=NULL, Factor=NULL,
         colnames(data_model)[which(colnames(data_model)=="time")] <- timeVar
         data_model <- data_model[,c("id",model_var)]
 
-        RE <- predRE(tree$model_param[[as.character(current_node)]][[1]],
+        RE <- predRE(tree$model_param[[as.numeric(current_node)]][[1]],
                      X$model[[var.split]], data_model)$bi
 
         ######################

--- a/R/predict.R
+++ b/R/predict.R
@@ -195,6 +195,9 @@ predict.DynForest <- function(object,
       Numeric <- NULL
     }
 
+  }else{
+    Factor <- NULL
+    Numeric <- NULL
   }
 
   #####################
@@ -243,7 +246,7 @@ predict.DynForest <- function(object,
 
           i.leaf <- pred_leaf[t,][indiv]
 
-          pred_leaf_indiv <- object$rf[,t]$Y_pred[[as.character(i.leaf)]][[cause]]$traj[id.predTimes]
+          pred_leaf_indiv <- object$rf[,t]$Y_pred[[as.numeric(i.leaf)]][[cause]]$traj[id.predTimes]
 
           if (!is.null(pred_leaf_indiv)){
             pred[[cause]][[indiv]][t,] <- pred_leaf_indiv
@@ -261,7 +264,7 @@ predict.DynForest <- function(object,
 
         i.leaf <- pred_leaf[t,indiv]
 
-        pred_leaf_indiv <- object$rf[,t]$Y_pred[[as.character(i.leaf)]]
+        pred_leaf_indiv <- object$rf[,t]$Y_pred[[as.numeric(i.leaf)]]
 
         if (!is.null(pred_leaf_indiv)){
           pred[t,indiv] <- pred_leaf_indiv


### PR DESCRIPTION
Hi Anthony Devaux,

When you try to run predict.DynForest with fixedData = NULL, errors occur
And when  you try to run predict.DynForest with an Y$type = 'surv', pred.dynforest$pred_indiv was full of zeros

Thanks for your work,

Quentin Laval